### PR TITLE
🐛 Fix err condition return

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -120,7 +120,7 @@ func NewDecoder(reader io.Reader) (dec *Decoder, err error) {
 			dec.readerLocker.Lock()
 			dec.decoderLocker.Lock()
 			dec.decodedData = append(dec.decodedData, decoded[:decodedLength]...)
-			if int(frameSize) < len(dec.data) {
+			if int(frameSize) <= len(dec.data) {
 				dec.data = dec.data[int(frameSize):]
 			}
 			dec.decoderLocker.Unlock()

--- a/decode.go
+++ b/decode.go
@@ -65,7 +65,7 @@ func NewDecoder(reader io.Reader) (dec *Decoder, err error) {
 		for {
 			select {
 			case <-dec.context.Done():
-				break
+				return
 			default:
 			}
 			if len(dec.data) > BufferSize {
@@ -91,7 +91,7 @@ func NewDecoder(reader io.Reader) (dec *Decoder, err error) {
 		for {
 			select {
 			case <-dec.context.Done():
-				break
+				return
 			default:
 			}
 			if len(dec.decodedData) > BufferSize {


### PR DESCRIPTION
To break a loop in `select`, `break` doesn't work.

When the file meets **EOF**, which means in the last but one round, `frameSize` is equal to `len(dec.data)`, if not set `dec.data = dec.data[int(frameSize):]`, then it would be an endless loop.